### PR TITLE
Added debian/docker requirements example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ executable, other than the default, set the PYTHON environment variable:
 export PYTHON=/path/to/python-2.6
 ```
 
+Debian/Docker example dependencies:
+```
+apt-get install python-libxml2 xutils-dev nvidia-cg-toolkit
+```
+
 The RSXGL library depends upon a toolchain that can generate binaries for the
 PS3's PPU, and also upon parts of the PSL1GHT SDK. The sample programs also
 require a few ported libraries, such as libpng, which are provided by


### PR DESCRIPTION
I added this because if you build it on the docker image `psl1ght/psl1ght` you need to add these deps, and it's quite useful for future reference.